### PR TITLE
Feat/domain

### DIFF
--- a/extensions/fastmail-masked-email/CHANGELOG.md
+++ b/extensions/fastmail-masked-email/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Fastmail Masked Email Changelog
 
+## Add Domain Field - {PR_MERGE_DATE}
+
+- Added domain field to the create command to allow users to specify a domain
+  when creating a new masked email.
+
 ## [Misc Extension Updates] - 2024-12-28
 
 - When a masked email is created, it will now be in the `pending` state. This allows

--- a/extensions/fastmail-masked-email/package.json
+++ b/extensions/fastmail-masked-email/package.json
@@ -7,7 +7,8 @@
   "author": "LightQuantum",
   "contributors": [
     "kpa",
-    "mike182uk"
+    "mike182uk",
+    "lucacome"
   ],
   "categories": [
     "Productivity",

--- a/extensions/fastmail-masked-email/src/create.tsx
+++ b/extensions/fastmail-masked-email/src/create.tsx
@@ -21,17 +21,18 @@ type Preferences = {
 type FormValues = {
   prefix: string;
   description: string;
+  domain: string;
 };
 
 export default function Command() {
   const [maskedEmail, setMaskedEmail] = useState<string>("");
   const { create_prefix } = getPreferenceValues<Preferences>();
 
-  const handleSubmit = async ({ prefix, description }: FormValues) => {
+  const handleSubmit = async ({ prefix, description, domain }: FormValues) => {
     const toast = await showToast({ style: Toast.Style.Animated, title: "Creating masked email..." });
 
     try {
-      const email = await createMaskedEmail(prefix, description);
+      const email = await createMaskedEmail(prefix, description, domain);
 
       Clipboard.copy(email);
 
@@ -48,11 +49,11 @@ export default function Command() {
     }
   };
 
-  const handleSubmitInteractive = async ({ prefix, description }: FormValues) => {
+  const handleSubmitInteractive = async ({ prefix, description, domain }: FormValues) => {
     const toast = await showToast({ style: Toast.Style.Animated, title: "Creating masked email..." });
 
     try {
-      const email = await createMaskedEmail(prefix, description);
+      const email = await createMaskedEmail(prefix, description, domain);
 
       setMaskedEmail(email);
 
@@ -99,6 +100,7 @@ A prefix must be <= 64 characters in length and only contain characters a-z, 0-9
         placeholder="What is this masked email for?"
         autoFocus={true}
       />
+      <Form.TextField id="domain" title="Domain (Optional)" placeholder="What is the domain for this masked email?" />
       {maskedEmail && (
         <>
           <Form.Description text={`\n${maskedEmail}\n`} />

--- a/extensions/fastmail-masked-email/src/fastmail.ts
+++ b/extensions/fastmail-masked-email/src/fastmail.ts
@@ -49,11 +49,12 @@ type CreateMaskedEmail = {
       state: MaskedEmailState;
       description?: string;
       emailPrefix?: string;
+      forDomain?: string;
     }
   >;
 };
 
-export async function createMaskedEmail(prefix = "", description = "") {
+export async function createMaskedEmail(prefix = "", description = "", domain = "") {
   const session = await getSession();
   const request: APIRequest<CreateMaskedEmail> = {
     using: ["urn:ietf:params:jmap:core", MaskedEmailCapability],
@@ -67,6 +68,7 @@ export async function createMaskedEmail(prefix = "", description = "") {
               state: MaskedEmailState.Pending,
               description,
               emailPrefix: normalisePrefix(prefix),
+              forDomain: domain,
             },
           },
         },

--- a/extensions/fastmail-masked-email/src/list.tsx
+++ b/extensions/fastmail-masked-email/src/list.tsx
@@ -131,7 +131,7 @@ export default function Command() {
             key={email.id}
             title={email.email}
             subtitle={email.forDomain || email.description}
-            keywords={[email.description]}
+            keywords={[email.description, email.forDomain]}
             accessories={[
               { date: new Date(email.createdAt), tooltip: `Created ${new Date(email.createdAt).toLocaleString()}` },
               accessoryForMaskedEmail(email),


### PR DESCRIPTION
Continuation of https://github.com/raycast/extensions/pull/18468 which was closed for inactivity. Not sure who's supposed to look at it since I appear the only active contributor 😅 

## Description

Add domain field to the create command to allow users to specify a domain when creating a new masked email.

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
